### PR TITLE
Make code conform to PEP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea/

--- a/src/nxfeature.py
+++ b/src/nxfeature.py
@@ -1,103 +1,112 @@
 #! /usr/bin/env python
 
-import h5py, numpy
-import importlib, sys, os
+import h5py
+import numpy
+import importlib
+import sys
+import os
 
 # print "%016X" % int("C0FFEEBEEFC0FFEE", 16)
 # feature = "C0FFEEBEEFC0FFEE"
 
-RECIPIE_DIR = os.path.dirname(os.path.realpath(__file__))+"/recipes"
+RECIPIE_DIR = os.path.dirname(os.path.realpath(__file__)) + "/recipes"
 sys.path.append(RECIPIE_DIR)
 
+
 class InsaneEntryWithFeatures:
-	def __init__(self, nxsfile, entrypath, featurearray):
-		self.nxsfile = nxsfile
-		self.entrypath = entrypath
-		self.featurearray = featurearray
+    def __init__(self, nxsfile, entrypath, featurearray):
+        self.nxsfile = nxsfile
+        self.entrypath = entrypath
+        self.featurearray = featurearray
 
-	def features(self):
-		return self.featurearray
-		
-	def feature_response(self, featureid):
-		featuremodule = importlib.import_module("%016X.recipe" % featureid)
-		r = featuremodule.recipe(self.nxsfile,self.entrypath)
-		return r.process()
+    def features(self):
+        return self.featurearray
 
-	def feature_title(self, featureid):
-		featuremodule = importlib.import_module("%016X.recipe" % featureid)
-		r = featuremodule.recipe(self.nxsfile,self.entrypath)
-		return r.title
+    def feature_response(self, featureid):
+        featuremodule = importlib.import_module("%016X.recipe" % featureid)
+        r = featuremodule.recipe(self.nxsfile, self.entrypath)
+        return r.process()
+
+    def feature_title(self, featureid):
+        featuremodule = importlib.import_module("%016X.recipe" % featureid)
+        r = featuremodule.recipe(self.nxsfile, self.entrypath)
+        return r.title
+
 
 class InsaneFeatureDiscoverer:
-	def __init__(self, nxsfile):
-		self.file = h5py.File(nxsfile, 'r')
+    def __init__(self, nxsfile):
+        self.file = h5py.File(nxsfile, 'r')
 
-	def entries(self):
-		ent = []
-		for entry in self.file.keys():
-			path = "/%s/features" % entry
-			try:
-				features = self.file[path]
-				if features.dtype == numpy.dtype("uint64"):
-					ent.append(InsaneEntryWithFeatures(self.file, entry, features))
-			except:
-				print "no features in "+path
-				pass
-		return ent
+    def entries(self):
+        ent = []
+        for entry in self.file.keys():
+            path = "/%s/features" % entry
+            try:
+                features = self.file[path]
+                if features.dtype == numpy.dtype("uint64"):
+                    ent.append(InsaneEntryWithFeatures(self.file, entry, features))
+            except:
+                print "no features in " + path
+                pass
+        return ent
+
 
 class AllFeatureDiscoverer:
-	def __init__(self, nxsfile):
-		self.file = h5py.File(nxsfile, 'r')
+    def __init__(self, nxsfile):
+        self.file = h5py.File(nxsfile, 'r')
 
-	def entries(self):
-		ent = []
-		for entry in self.file.keys():
-			try:
-				features = [int(feat, 16) for feat in os.listdir(RECIPIE_DIR)]
-				ent.append(InsaneEntryWithFeatures(self.file, entry, features))
-			except:
-				print "no recipies in "+RECIPIE_DIR
-				pass
-		return ent
-		
+    def entries(self):
+        ent = []
+        for entry in self.file.keys():
+            try:
+                features = [int(feat, 16) for feat in os.listdir(RECIPIE_DIR)]
+                ent.append(InsaneEntryWithFeatures(self.file, entry, features))
+            except:
+                print "no recipies in " + RECIPIE_DIR
+                pass
+        return ent
+
+
 if __name__ == '__main__':
-	import optparse
-	usage = "%prog [options] nxs_file"
-	parser = optparse.OptionParser(usage=usage)
-	parser.add_option("-t", "--test", dest="test", help="Test file against all recipies", action="store_true", default=False)
-	
-	(options, args) = parser.parse_args()
-	
-	if options.test:
-		disco = AllFeatureDiscoverer(args[0])
-	else:
-		disco = InsaneFeatureDiscoverer(args[0])
-	
-	for entry in disco.entries():
-		fail_list = []
-		error_list = []
-		
-		print("Entry \"%s\" appears to contain the following features (they validate correctly): " % entry.entrypath)
-		for feat in entry.features():
-			try:
-				response = entry.feature_response(feat)
-				print("\t%s (%d) %s" % (entry.feature_title(feat), feat, response))
-			except AssertionError as ae:
-				fail_list.append((feat, ae.message))
-			except Exception as e:
-				fail_list.append((feat, "Undefined validation error:(%s)" % e.message ))
-	
-		if len(fail_list) > 0:
-			print("\nThe following features failed to validate:")
-			for feat, message in fail_list:
-				try:
-					print("\t%s (%d) is invalid with the following errors:" % (entry.feature_title(feat), feat))
-					print("\t\t"+message.replace('\n', '\n\t\t'))
-				except:
-					error_list.append(feat)
-		
-		if len(error_list) > 0:
-			print("\nThe following features had unexpected errors (Are you running windows?):")
-			for feat in error_list:
-				print("  (%d)" % (feat))
-		print("\n")
+    import optparse
+
+    usage = "%prog [options] nxs_file"
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option("-t", "--test", dest="test", help="Test file against all recipies", action="store_true",
+                      default=False)
+
+    (options, args) = parser.parse_args()
+
+    if options.test:
+        disco = AllFeatureDiscoverer(args[0])
+    else:
+        disco = InsaneFeatureDiscoverer(args[0])
+
+    for entry in disco.entries():
+        fail_list = []
+        error_list = []
+
+        print("Entry \"%s\" appears to contain the following features (they validate correctly): " % entry.entrypath)
+        for feat in entry.features():
+            try:
+                response = entry.feature_response(feat)
+                print("\t%s (%d) %s" % (entry.feature_title(feat), feat, response))
+            except AssertionError as ae:
+                fail_list.append((feat, ae.message))
+            except Exception as e:
+                fail_list.append((feat, "Undefined validation error:(%s)" % e.message))
+
+        if len(fail_list) > 0:
+            print("\nThe following features failed to validate:")
+            for feat, message in fail_list:
+                try:
+                    print("\t%s (%d) is invalid with the following errors:" % (entry.feature_title(feat), feat))
+                    print("\t\t" + message.replace('\n', '\n\t\t'))
+                except:
+                    error_list.append(feat)
+
+        if len(error_list) > 0:
+            print("\nThe following features had unexpected errors (Are you running windows?):")
+            for feat in error_list:
+                print("  (%d)" % (feat))
+        print("\n")

--- a/src/recipes/0000000000000001/recipe.py
+++ b/src/recipes/0000000000000001/recipe.py
@@ -1,10 +1,10 @@
 def check_nframes(context, nxTomo, item, values, fails):
     frames = nxTomo[item].shape[0];
-    if (not 'nFrames' in context.keys()) and frames != 1:
+    if ('nFrames' not in context.keys()) and frames != 1:
         context['nFrames'] = frames
         context['nFrames_item'] = item
     else:
-        if not frames in [context['nFrames'], 1]:
+        if frames not in [context['nFrames'], 1]:
             fails.append("'%s' does not have the same number of frames as '%s'" % (item, context['nFrames_item']))
 
 

--- a/src/recipes/0000000000000001/recipe.py
+++ b/src/recipes/0000000000000001/recipe.py
@@ -118,7 +118,6 @@ class recipe:
         if len(nxTomoList) == 0:
             raise AssertionError("No NXtomo entries in this entry")
         entries = []
-        failures = []
         for NXtomoEntry in nxTomoList:
             entries.append(validate(NXtomoEntry))
         return entries

--- a/src/recipes/0000000000000001/recipe.py
+++ b/src/recipes/0000000000000001/recipe.py
@@ -1,5 +1,5 @@
 def check_nframes(context, nxTomo, item, values, fails):
-    frames = nxTomo[item].shape[0];
+    frames = nxTomo[item].shape[0]
     if ('nFrames' not in context.keys()) and frames != 1:
         context['nFrames'] = frames
         context['nFrames_item'] = item
@@ -9,7 +9,7 @@ def check_nframes(context, nxTomo, item, values, fails):
 
 
 def include_data(context, nxTomo, item, values, fails):
-    values[item] = nxTomo[item];
+    values[item] = nxTomo[item]
 
 
 def check_image_keys(context, nxTomo, item, values, fails):

--- a/src/recipes/0000000000000001/recipe.py
+++ b/src/recipes/0000000000000001/recipe.py
@@ -1,118 +1,124 @@
 def check_nframes(context, nxTomo, item, values, fails):
-	frames = nxTomo[item].shape[0];
-	if (not 'nFrames' in context.keys()) and frames != 1:
-		context['nFrames'] = frames
-		context['nFrames_item'] = item
-	else :
-		if not frames in [context['nFrames'], 1]:
-			fails.append("'%s' does not have the same number of frames as '%s'" % (item, context['nFrames_item']))
+    frames = nxTomo[item].shape[0];
+    if (not 'nFrames' in context.keys()) and frames != 1:
+        context['nFrames'] = frames
+        context['nFrames_item'] = item
+    else:
+        if not frames in [context['nFrames'], 1]:
+            fails.append("'%s' does not have the same number of frames as '%s'" % (item, context['nFrames_item']))
+
 
 def include_data(context, nxTomo, item, values, fails):
-	values[item] = nxTomo[item];
-		
+    values[item] = nxTomo[item];
+
+
 def check_image_keys(context, nxTomo, item, values, fails):
-	data = nxTomo[item][...]
-	if data.max() > 3 or data.min() < 0:
-		fails.append("'%s' has values outside of the normal range 0 to 3" % (item))
+    data = nxTomo[item][...]
+    if data.max() > 3 or data.min() < 0:
+        fails.append("'%s' has values outside of the normal range 0 to 3" % (item))
 
 
 INCLUDE_DATA = 'include_data'
 CHECK_NFRAMES = 'check_nframes'
 CHECK_IMAGE_KEYS = 'check_image_keys'
 VALIDATE = {
-			"control": [],
-			"control/data": [check_nframes], 
-			"data":[],
-			"data/image_key":[include_data, check_image_keys],
-			"data/rotation_angle":[include_data,check_nframes],
-			"data/data":[include_data,check_nframes],
-			"definition":[],
-			"instrument":[],
-			"instrument/detector":[],
-			"instrument/detector/data":[check_nframes],
-			"instrument/detector/distance":[],
-			"instrument/detector/image_key":[check_nframes, check_image_keys],
-			"instrument/detector/x_pixel_size":[],
-			"instrument/detector/y_pixel_size":[],
-			"instrument/detector/x_rotation_axis_pixel_position":[],
-			"instrument/detector/y_rotation_axis_pixel_position":[],
-			"instrument/source":[],
-			"instrument/source/current":[],
-			"instrument/source/energy":[],
-			"instrument/source/name":[],
-			"instrument/source/probe":[],
-			"instrument/source/type":[],
-			"sample":[],
-			"sample/name":[],
-			"sample/rotation_angle":[check_nframes],
-			"sample/x_translation":[check_nframes],
-			"sample/y_translation":[check_nframes],
-			"sample/z_translation":[check_nframes],
-			"title":[],
-			"start_time":[],
-			"end_time":[],
-			}
+    "control": [],
+    "control/data": [check_nframes],
+    "data": [],
+    "data/image_key": [include_data, check_image_keys],
+    "data/rotation_angle": [include_data, check_nframes],
+    "data/data": [include_data, check_nframes],
+    "definition": [],
+    "instrument": [],
+    "instrument/detector": [],
+    "instrument/detector/data": [check_nframes],
+    "instrument/detector/distance": [],
+    "instrument/detector/image_key": [check_nframes, check_image_keys],
+    "instrument/detector/x_pixel_size": [],
+    "instrument/detector/y_pixel_size": [],
+    "instrument/detector/x_rotation_axis_pixel_position": [],
+    "instrument/detector/y_rotation_axis_pixel_position": [],
+    "instrument/source": [],
+    "instrument/source/current": [],
+    "instrument/source/energy": [],
+    "instrument/source/name": [],
+    "instrument/source/probe": [],
+    "instrument/source/type": [],
+    "sample": [],
+    "sample/name": [],
+    "sample/rotation_angle": [check_nframes],
+    "sample/x_translation": [check_nframes],
+    "sample/y_translation": [check_nframes],
+    "sample/z_translation": [check_nframes],
+    "title": [],
+    "start_time": [],
+    "end_time": [],
+}
+
 
 class _NXTomoFinder(object):
-	def __init__(self):
-		self.hits = []
+    def __init__(self):
+        self.hits = []
 
-	def _visit_NXtomo(self, name, obj):
-		if "NX_class" in obj.attrs.keys():
-			if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
-				if "definition" in obj.keys():
-					if obj["definition"][0] == "NXtomo":
-						self.hits.append(obj)
-	
-	def get_NXtomo(self, nx_file, entry):
-		self.hits = []
-		nx_file[entry].visititems(self._visit_NXtomo)
-		return self.hits
+    def _visit_NXtomo(self, name, obj):
+        if "NX_class" in obj.attrs.keys():
+            if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
+                if "definition" in obj.keys():
+                    if obj["definition"][0] == "NXtomo":
+                        self.hits.append(obj)
+
+    def get_NXtomo(self, nx_file, entry):
+        self.hits = []
+        nx_file[entry].visititems(self._visit_NXtomo)
+        return self.hits
+
 
 def check_path(entry, path):
-	section = entry
-	for part in path.split('/'):
-		if part in section.keys():
-			section = section[part]
-		else :
-			return False
-	return True
+    section = entry
+    for part in path.split('/'):
+        if part in section.keys():
+            section = section[part]
+        else:
+            return False
+    return True
+
 
 def validate(nxTomo):
-	context = {}
-	values = {}
-	fails = []
+    context = {}
+    values = {}
+    fails = []
 
-	for item in VALIDATE.keys():
-		if check_path(nxTomo, item):
-			for test in VALIDATE[item]:
-				test(context, nxTomo, item, values, fails)
-		else:
-			fails.append("'NXtomo/%s' is missing from the NXtomo entry" % (item))
-	if len(fails) > 0:
-		raise AssertionError('\n'.join(fails))
-	return values
+    for item in VALIDATE.keys():
+        if check_path(nxTomo, item):
+            for test in VALIDATE[item]:
+                test(context, nxTomo, item, values, fails)
+        else:
+            fails.append("'NXtomo/%s' is missing from the NXtomo entry" % (item))
+    if len(fails) > 0:
+        raise AssertionError('\n'.join(fails))
+    return values
+
 
 class recipe:
-	"""
-		This is meant to help consumers of this feature to understand how to implement 
-		code that understands that feature (copy and paste of the code is allowed).
-		It also documents in what preference order (if any) certain things are evaluated
-		when finding the information.
-	"""
+    """
+        This is meant to help consumers of this feature to understand how to implement
+        code that understands that feature (copy and paste of the code is allowed).
+        It also documents in what preference order (if any) certain things are evaluated
+        when finding the information.
+    """
 
-	def __init__(self, filedesc, entrypath):
-		self.file = filedesc
-		self.entry = entrypath
-		self.title = "NXtomo"
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "NXtomo"
 
-	def process(self):
-		nxTomo = _NXTomoFinder()
-		nxTomoList = nxTomo.get_NXtomo(self.file, self.entry)
-		if len(nxTomoList) == 0:
-			 raise AssertionError("No NXtomo entries in this entry")
-		entries = []
-		failures = []
-		for NXtomoEntry in nxTomoList:
-			entries.append(validate(NXtomoEntry))
-		return entries
+    def process(self):
+        nxTomo = _NXTomoFinder()
+        nxTomoList = nxTomo.get_NXtomo(self.file, self.entry)
+        if len(nxTomoList) == 0:
+            raise AssertionError("No NXtomo entries in this entry")
+        entries = []
+        failures = []
+        for NXtomoEntry in nxTomoList:
+            entries.append(validate(NXtomoEntry))
+        return entries

--- a/src/recipes/0000000000000002/recipe.py
+++ b/src/recipes/0000000000000002/recipe.py
@@ -1,29 +1,31 @@
 def _visit_NXdetector_with_image_key(name, obj):
-	if "NX_class" in obj.attrs.keys():
-		if obj.attrs["NX_class"] in ["NXdetector"]:
-			if "image_key" in obj.keys():
-				return obj
+    if "NX_class" in obj.attrs.keys():
+        if obj.attrs["NX_class"] in ["NXdetector"]:
+            if "image_key" in obj.keys():
+                return obj
+
 
 def get_NXdetector_with_image_key(nx_file, entry):
-	return nx_file[entry].visititems(_visit_NXdetector_with_image_key)
+    return nx_file[entry].visititems(_visit_NXdetector_with_image_key)
+
 
 class recipe:
-	"""
-		A demo recipe for finding the information associated with this demo feature.
-		
-		This is meant to help consumers of this feature to understand how to implement 
-		code that understands that feature (copy and paste of the code is allowed).
-		It also documents in what preference order (if any) certain things are evaluated
-		when finding the information.
-	"""
+    """
+        A demo recipe for finding the information associated with this demo feature.
 
-	def __init__(self, filedesc, entrypath):
-		self.file = filedesc
-		self.entry = entrypath
-		self.title = "NXdetector with image key"
+        This is meant to help consumers of this feature to understand how to implement
+        code that understands that feature (copy and paste of the code is allowed).
+        It also documents in what preference order (if any) certain things are evaluated
+        when finding the information.
+    """
 
-	def process(self):
-		nxDet = get_NXdetector_with_image_key(self.file, self.entry)
-		if nxDet is not None:
-			return {"NXdetector with image_key" : nxDet}
-		raise AssertionError("This file does not contain an NXdetector with the image_key field")
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "NXdetector with image key"
+
+    def process(self):
+        nxDet = get_NXdetector_with_image_key(self.file, self.entry)
+        if nxDet is not None:
+            return {"NXdetector with image_key": nxDet}
+        raise AssertionError("This file does not contain an NXdetector with the image_key field")

--- a/src/recipes/0000000000000003/recipe.py
+++ b/src/recipes/0000000000000003/recipe.py
@@ -1,27 +1,29 @@
 def _visit_gda_scan_command(name, obj):
-	if "scan_command" in obj.name:
-		return obj[0]
+    if "scan_command" in obj.name:
+        return obj[0]
+
 
 def get_gda_scan_command(nx_file, entry):
-	return nx_file[entry].visititems(_visit_gda_scan_command)
+    return nx_file[entry].visititems(_visit_gda_scan_command)
+
 
 class recipe:
-	"""
-		A demo recipe for finding the information associated with this demo feature.
-		
-		This is meant to help consumers of this feature to understand how to implement 
-		code that understands that feature (copy and paste of the code is allowed).
-		It also documents in what preference order (if any) certain things are evaluated
-		when finding the information.
-	"""
+    """
+        A demo recipe for finding the information associated with this demo feature.
 
-	def __init__(self, filedesc, entrypath):
-		self.file = filedesc
-		self.entry = entrypath
-		self.title = "GDA scan command"
+        This is meant to help consumers of this feature to understand how to implement
+        code that understands that feature (copy and paste of the code is allowed).
+        It also documents in what preference order (if any) certain things are evaluated
+        when finding the information.
+    """
 
-	def process(self):
-		gda_scan = get_gda_scan_command(self.file, self.entry)
-		if gda_scan is not None:
-			return {"GDA scan command" : gda_scan}
-		raise AssertionError("There is no GDA scan command in this file.")
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "GDA scan command"
+
+    def process(self):
+        gda_scan = get_gda_scan_command(self.file, self.entry)
+        if gda_scan is not None:
+            return {"GDA scan command": gda_scan}
+        raise AssertionError("There is no GDA scan command in this file.")

--- a/src/recipes/0000000000000006/recipe.py
+++ b/src/recipes/0000000000000006/recipe.py
@@ -9,7 +9,7 @@ class check_dtype(object):
 
     def __call__(self, dset):
         dtype = dset.dtype
-        if not dtype in self.dtype:
+        if dtype not in self.dtype:
             return False, "%s is type %s, expected %s" % (
                 dset.name, dtype, ', '.join(self.dtype))
         return True, ""
@@ -103,7 +103,7 @@ class check_dset(object):
     def __call__(self, dset):
         for check in self.checks:
             passed, errors = check(dset)
-            if passed == False:
+            if not passed:
                 raise RuntimeError(errors)
 
 
@@ -126,7 +126,7 @@ class check_attr(object):
         self.dtype = dtype
 
     def __call__(self, dset):
-        if not self.name in dset.attrs.keys():
+        if self.name not in dset.attrs.keys():
             raise RuntimeError("'%s' does not have an attribute '%s'" % (
                 dset.name, self.name))
         elif self.value is not None and dset.attrs[self.name] != self.value:

--- a/src/recipes/0000000000000006/recipe.py
+++ b/src/recipes/0000000000000006/recipe.py
@@ -1,8 +1,8 @@
 class check_dtype(object):
-    '''
+    """
     A class to check whether the dataset data type matches the expected
 
-    '''
+    """
 
     def __init__(self, dtype):
         self.dtype = dtype
@@ -16,10 +16,10 @@ class check_dtype(object):
 
 
 class check_dims(object):
-    '''
+    """
     A class to check whether the dataset dimensions matches the expected
 
-    '''
+    """
 
     def __init__(self, dims):
         self.dims = dims
@@ -33,10 +33,10 @@ class check_dims(object):
 
 
 class check_shape(object):
-    '''
+    """
     A class to check whether the dataset shape matches the expected
 
-    '''
+    """
 
     def __init__(self, shape):
         self.shape = shape
@@ -50,10 +50,10 @@ class check_shape(object):
 
 
 class check_is_scalar(object):
-    '''
+    """
     A class to check whether the dataset is scalar or not
 
-    '''
+    """
 
     def __init__(self, is_scalar):
         self.is_scalar = is_scalar
@@ -71,23 +71,23 @@ class check_is_scalar(object):
 
 
 class check_dset(object):
-    '''
+    """
     Check properties of a dataset
 
-    '''
+    """
 
     def __init__(self,
                  dtype=None,
                  dims=None,
                  shape=None,
                  is_scalar=None):
-        '''
+        """
         Set stuff to check
         :param dtype:         The datatype
         :param dims:          The number of dimensions
         :param shape:         The shape of the dataset
 
-        '''
+        """
         self.checks = []
         if dtype is not None:
             if not isinstance(dtype, list) and not isinstance(dtype, tuple):
@@ -108,19 +108,19 @@ class check_dset(object):
 
 
 class check_attr(object):
-    '''
+    """
     Check some properties of an attribute
 
-    '''
+    """
 
     def __init__(self, name, value=None, dtype=None):
-        '''
+        """
         Set stuff to check
         :param name:  The name of the attribute
         :param value: The value of the attribute
         :param tests: A list of tests to run
 
-        '''
+        """
         self.name = name
         self.value = value
         self.dtype = dtype
@@ -140,10 +140,10 @@ class check_attr(object):
 
 
 def find_entries(nx_file, entry):
-    '''
+    """
     Find NXmx entries
 
-    '''
+    """
     hits = []
 
     def visitor(name, obj):
@@ -159,10 +159,10 @@ def find_entries(nx_file, entry):
 
 
 def find_class(nx_file, nx_class):
-    '''
+    """
     Find a given NXclass
 
-    '''
+    """
     hits = []
 
     def visitor(name, obj):
@@ -175,10 +175,10 @@ def find_class(nx_file, nx_class):
 
 
 def convert_units(value, input_units, output_units):
-    '''
+    """
     Hacky utility function to convert units
 
-    '''
+    """
     converters = {
         'm': {
             'mm': lambda x: x * 1e3,
@@ -212,10 +212,10 @@ def convert_units(value, input_units, output_units):
 
 
 def visit_dependancies(nx_file, item, visitor=None):
-    '''
+    """
     Walk the dependency chain and call a visitor function
 
-    '''
+    """
     import os.path
     dependency_chain = []
     if os.path.basename(item) == 'depends_on':
@@ -239,10 +239,10 @@ def visit_dependancies(nx_file, item, visitor=None):
 
 
 def construct_vector(nx_file, item, vector=None):
-    '''
+    """
     Walk the dependency chain and create the absolute vector
 
-    '''
+    """
     from scitbx import matrix
 
     class TransformVisitor(object):
@@ -291,10 +291,10 @@ def construct_vector(nx_file, item, vector=None):
 
 
 def run_checks(handle, items):
-    '''
+    """
     Run checks for datasets
 
-    '''
+    """
     from os.path import join
     for item, detail in items.iteritems():
         min_occurs = detail["minOccurs"]
@@ -314,10 +314,10 @@ def run_checks(handle, items):
 
 
 class NXdetector_module(object):
-    '''
+    """
     A class to hold a handle to NXdetector_module
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
         self.handle = handle
@@ -374,10 +374,10 @@ class NXdetector_module(object):
 
 
 class NXdetector(object):
-    '''
+    """
     A class to handle a handle to NXdetector
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
 
@@ -549,10 +549,10 @@ class NXdetector(object):
 
 
 class NXinstrument(object):
-    '''
+    """
     A class to hold a handle to NXinstrument
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
 
@@ -573,10 +573,10 @@ class NXinstrument(object):
 
 
 class NXbeam(object):
-    '''
+    """
     A class to hold a handle to NXbeam
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
         self.handle = handle
@@ -610,10 +610,10 @@ class NXbeam(object):
 
 
 class NXsample(object):
-    '''
+    """
     A class to hold a handle to NXsample
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
 
@@ -681,20 +681,20 @@ class NXsample(object):
 
 
 class NXdata(object):
-    '''
+    """
     A class to hold a handle to NXdata
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
         self.handle = handle
 
 
 class NXmxEntry(object):
-    '''
+    """
     A class to hold a handle to NXmx entries
 
-    '''
+    """
 
     def __init__(self, handle, errors=None):
 
@@ -754,10 +754,10 @@ class NXmxEntry(object):
 
 
 def validate(nx_file, item, test):
-    '''
+    """
     Validate the NXmx entries
 
-    '''
+    """
     values = []
     fails = []
     context = {}
@@ -768,10 +768,10 @@ def validate(nx_file, item, test):
 
 
 def check_path(nx_file, path):
-    '''
+    """
     Ensure path exists
 
-    '''
+    """
     section = nx_file
     try:
         nx_file[path]
@@ -805,14 +805,14 @@ class recipe:
 
         # Check we've got some stuff
         if len(self.entries) == 0:
-            raise RuntimeError('''
+            raise RuntimeError("""
         Error reading NXmxfile: %s
           No NXmx entries in file
 
         The following errors occurred:
 
         %s
-      ''' % (self.file.filename, "\n".join(self.errors)))
+      """ % (self.file.filename, "\n".join(self.errors)))
 
 
 if __name__ == '__main__':

--- a/src/recipes/0000000000000006/recipe.py
+++ b/src/recipes/0000000000000006/recipe.py
@@ -1,807 +1,811 @@
-
-
 class check_dtype(object):
-  '''
-  A class to check whether the dataset data type matches the expected
+    '''
+    A class to check whether the dataset data type matches the expected
 
-  '''
+    '''
 
-  def __init__(self, dtype):
-    self.dtype = dtype
+    def __init__(self, dtype):
+        self.dtype = dtype
 
-  def __call__(self, dset):
-    dtype = dset.dtype
-    if not dtype in self.dtype:
-      return False, "%s is type %s, expected %s" % (
-        dset.name, dtype, ', '.join(self.dtype))
-    return True, ""
+    def __call__(self, dset):
+        dtype = dset.dtype
+        if not dtype in self.dtype:
+            return False, "%s is type %s, expected %s" % (
+                dset.name, dtype, ', '.join(self.dtype))
+        return True, ""
+
 
 class check_dims(object):
-  '''
-  A class to check whether the dataset dimensions matches the expected
+    '''
+    A class to check whether the dataset dimensions matches the expected
 
-  '''
+    '''
 
-  def __init__(self, dims):
-    self.dims = dims
+    def __init__(self, dims):
+        self.dims = dims
 
-  def __call__(self, dset):
-    dims = len(dset.shape)
-    if not dims == self.dims:
-      return False, '%s has dims %s, expected %s' % (
-        dset.name, str(dims), str(self.dims))
-    return True, ''
+    def __call__(self, dset):
+        dims = len(dset.shape)
+        if not dims == self.dims:
+            return False, '%s has dims %s, expected %s' % (
+                dset.name, str(dims), str(self.dims))
+        return True, ''
+
 
 class check_shape(object):
-  '''
-  A class to check whether the dataset shape matches the expected
+    '''
+    A class to check whether the dataset shape matches the expected
 
-  '''
+    '''
 
-  def __init__(self, shape):
-    self.shape = shape
+    def __init__(self, shape):
+        self.shape = shape
 
-  def __call__(self, dset):
-    shape = dset.shape
-    if not shape == self.shape:
-      return False, '%s has shape %s, expected %s' % (
-        dset.name, str(shape), str(self.shape))
-    return True, ''
+    def __call__(self, dset):
+        shape = dset.shape
+        if not shape == self.shape:
+            return False, '%s has shape %s, expected %s' % (
+                dset.name, str(shape), str(self.shape))
+        return True, ''
+
 
 class check_is_scalar(object):
-  '''
-  A class to check whether the dataset is scalar or not
+    '''
+    A class to check whether the dataset is scalar or not
 
-  '''
+    '''
 
-  def __init__(self, is_scalar):
-    self.is_scalar = is_scalar
+    def __init__(self, is_scalar):
+        self.is_scalar = is_scalar
 
-  def __call__(self, dset):
-    try:
-      data = dset[()]
-      s = True
-    except Exception:
-      s = False
-    if s != self.is_scalar:
-      return False, '%s == scalar is %s, expected %s' % (
-        dset.name, s, self.is_scalar)
-    return True, ''
+    def __call__(self, dset):
+        try:
+            data = dset[()]
+            s = True
+        except Exception:
+            s = False
+        if s != self.is_scalar:
+            return False, '%s == scalar is %s, expected %s' % (
+                dset.name, s, self.is_scalar)
+        return True, ''
+
 
 class check_dset(object):
-  '''
-  Check properties of a dataset
-
-  '''
-
-  def __init__(self,
-               dtype=None,
-               dims=None,
-               shape=None,
-               is_scalar=None):
     '''
-    Set stuff to check
-    :param dtype:         The datatype
-    :param dims:          The number of dimensions
-    :param shape:         The shape of the dataset
+    Check properties of a dataset
 
     '''
-    self.checks = []
-    if dtype is not None:
-      if not isinstance(dtype, list) and not isinstance(dtype, tuple):
-        dtype = [dtype]
-      self.checks.append(check_dtype(dtype))
-    if dims is not None:
-      self.checks.append(check_dims(dims))
-    if shape is not None:
-      self.checks.append(check_shape(shape))
-    if is_scalar is not None:
-      self.checks.append(check_is_scalar(is_scalar))
 
-  def __call__(self, dset):
-    for check in self.checks:
-      passed, errors = check(dset)
-      if passed == False:
-        raise RuntimeError(errors)
+    def __init__(self,
+                 dtype=None,
+                 dims=None,
+                 shape=None,
+                 is_scalar=None):
+        '''
+        Set stuff to check
+        :param dtype:         The datatype
+        :param dims:          The number of dimensions
+        :param shape:         The shape of the dataset
+
+        '''
+        self.checks = []
+        if dtype is not None:
+            if not isinstance(dtype, list) and not isinstance(dtype, tuple):
+                dtype = [dtype]
+            self.checks.append(check_dtype(dtype))
+        if dims is not None:
+            self.checks.append(check_dims(dims))
+        if shape is not None:
+            self.checks.append(check_shape(shape))
+        if is_scalar is not None:
+            self.checks.append(check_is_scalar(is_scalar))
+
+    def __call__(self, dset):
+        for check in self.checks:
+            passed, errors = check(dset)
+            if passed == False:
+                raise RuntimeError(errors)
 
 
 class check_attr(object):
-  '''
-  Check some properties of an attribute
-
-  '''
-
-  def __init__(self, name, value=None, dtype=None):
     '''
-    Set stuff to check
-    :param name:  The name of the attribute
-    :param value: The value of the attribute
-    :param tests: A list of tests to run
+    Check some properties of an attribute
 
     '''
-    self.name = name
-    self.value = value
-    self.dtype = dtype
 
-  def __call__(self, dset):
-    if not self.name in dset.attrs.keys():
-      raise RuntimeError("'%s' does not have an attribute '%s'" % (
-        dset.name, self.name))
-    elif self.value is not None and dset.attrs[self.name] != self.value:
-      raise RuntimeError("attribute '%s' of %s has value %s, expected %s" % (
-        self.name, dset.name, dset.attrs[self.name], self.value))
-    elif self.dtype is not None:
-      dtype = type(dset.attrs[self.name])
-      if not isinstance(dset.attrs[self.name],self.dtype):
-        raise RuntimeError("attribute '%s' of '%s' has type %s, expected %s" % (
-          self.name, dset.name, dtype, self.dtype))
+    def __init__(self, name, value=None, dtype=None):
+        '''
+        Set stuff to check
+        :param name:  The name of the attribute
+        :param value: The value of the attribute
+        :param tests: A list of tests to run
+
+        '''
+        self.name = name
+        self.value = value
+        self.dtype = dtype
+
+    def __call__(self, dset):
+        if not self.name in dset.attrs.keys():
+            raise RuntimeError("'%s' does not have an attribute '%s'" % (
+                dset.name, self.name))
+        elif self.value is not None and dset.attrs[self.name] != self.value:
+            raise RuntimeError("attribute '%s' of %s has value %s, expected %s" % (
+                self.name, dset.name, dset.attrs[self.name], self.value))
+        elif self.dtype is not None:
+            dtype = type(dset.attrs[self.name])
+            if not isinstance(dset.attrs[self.name], self.dtype):
+                raise RuntimeError("attribute '%s' of '%s' has type %s, expected %s" % (
+                    self.name, dset.name, dtype, self.dtype))
 
 
 def find_entries(nx_file, entry):
-  '''
-  Find NXmx entries
+    '''
+    Find NXmx entries
 
-  '''
-  hits = []
-  def visitor(name, obj):
-    if "NX_class" in obj.attrs.keys():
-      if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
-        if "definition" in obj.keys():
-          if obj["definition"][()] == "NXmx":
-            hits.append(obj)
-  visitor(entry, nx_file[entry])
-  nx_file[entry].visititems(visitor)
-  return hits
+    '''
+    hits = []
+
+    def visitor(name, obj):
+        if "NX_class" in obj.attrs.keys():
+            if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
+                if "definition" in obj.keys():
+                    if obj["definition"][()] == "NXmx":
+                        hits.append(obj)
+
+    visitor(entry, nx_file[entry])
+    nx_file[entry].visititems(visitor)
+    return hits
 
 
 def find_class(nx_file, nx_class):
-  '''
-  Find a given NXclass
+    '''
+    Find a given NXclass
 
-  '''
-  hits = []
-  def visitor(name, obj):
-    if "NX_class" in obj.attrs.keys():
-      if obj.attrs["NX_class"] in [nx_class]:
-        hits.append(obj)
-  nx_file.visititems(visitor)
-  return hits
+    '''
+    hits = []
+
+    def visitor(name, obj):
+        if "NX_class" in obj.attrs.keys():
+            if obj.attrs["NX_class"] in [nx_class]:
+                hits.append(obj)
+
+    nx_file.visititems(visitor)
+    return hits
 
 
 def convert_units(value, input_units, output_units):
-  '''
-  Hacky utility function to convert units
+    '''
+    Hacky utility function to convert units
 
-  '''
-  converters = {
-    'm' : {
-      'mm'        : lambda x: x * 1e3,
-      'microns'   : lambda x: x * 1e6,
-      'nm'        : lambda x: x * 1e9
-    },
-    'mm' : {
-      'm'         : lambda x: x * 1e-3,
-      'microns'   : lambda x: x * 1e3,
-      'nm'        : lambda x: x * 1e6
-    },
-    'microns' : {
-      'm'         : lambda x: x * 1e-6,
-      'mm'        : lambda x: x * 1e-3,
-      'nm'        : lambda x: x * 1e3
-    },
-    'nm' : {
-      'm'         : lambda x: x * 1e-9,
-      'mm'        : lambda x: x * 1e-6,
-      'microns'   : lambda x: x * 1e-3,
-      'angstroms' : lambda x: x * 10
+    '''
+    converters = {
+        'm': {
+            'mm': lambda x: x * 1e3,
+            'microns': lambda x: x * 1e6,
+            'nm': lambda x: x * 1e9
+        },
+        'mm': {
+            'm': lambda x: x * 1e-3,
+            'microns': lambda x: x * 1e3,
+            'nm': lambda x: x * 1e6
+        },
+        'microns': {
+            'm': lambda x: x * 1e-6,
+            'mm': lambda x: x * 1e-3,
+            'nm': lambda x: x * 1e3
+        },
+        'nm': {
+            'm': lambda x: x * 1e-9,
+            'mm': lambda x: x * 1e-6,
+            'microns': lambda x: x * 1e-3,
+            'angstroms': lambda x: x * 10
+        }
     }
-  }
-  if input_units == output_units:
-    return value
-  try:
-    return converters[input_units][output_units](value)
-  except Exception, e:
-    pass
-  raise RuntimeError('Can\'t convert units "%s" to "%s"' % (input_units, output_units))
-
-
-def visit_dependancies(nx_file, item, visitor = None):
-  '''
-  Walk the dependency chain and call a visitor function
-
-  '''
-  import os.path
-  dependency_chain = []
-  if os.path.basename(item) == 'depends_on':
-    depends_on = nx_file[item][()]
-  else:
-    depends_on = nx_file[item].attrs['depends_on']
-  while not depends_on == ".":
-    if visitor is not None:
-      visitor(nx_file, depends_on)
-    if depends_on in dependency_chain:
-      raise RuntimeError("'%s' is a circular dependency" % depends_on)
+    if input_units == output_units:
+        return value
     try:
-      item = nx_file[depends_on]
+        return converters[input_units][output_units](value)
     except Exception, e:
-      raise RuntimeError("'%s' is missing from nx_file" % depends_on)
-    dependency_chain.append(depends_on)
-    try:
-      depends_on = nx_file[depends_on].attrs["depends_on"]
-    except Exception:
-      raise RuntimeError("'%s' contains no depends_on attribute" % depends_on)
+        pass
+    raise RuntimeError('Can\'t convert units "%s" to "%s"' % (input_units, output_units))
+
+
+def visit_dependancies(nx_file, item, visitor=None):
+    '''
+    Walk the dependency chain and call a visitor function
+
+    '''
+    import os.path
+    dependency_chain = []
+    if os.path.basename(item) == 'depends_on':
+        depends_on = nx_file[item][()]
+    else:
+        depends_on = nx_file[item].attrs['depends_on']
+    while not depends_on == ".":
+        if visitor is not None:
+            visitor(nx_file, depends_on)
+        if depends_on in dependency_chain:
+            raise RuntimeError("'%s' is a circular dependency" % depends_on)
+        try:
+            item = nx_file[depends_on]
+        except Exception, e:
+            raise RuntimeError("'%s' is missing from nx_file" % depends_on)
+        dependency_chain.append(depends_on)
+        try:
+            depends_on = nx_file[depends_on].attrs["depends_on"]
+        except Exception:
+            raise RuntimeError("'%s' contains no depends_on attribute" % depends_on)
 
 
 def construct_vector(nx_file, item, vector=None):
-  '''
-  Walk the dependency chain and create the absolute vector
+    '''
+    Walk the dependency chain and create the absolute vector
 
-  '''
-  from scitbx import matrix
+    '''
+    from scitbx import matrix
 
-  class TransformVisitor(object):
-    def __init__(self, vector):
-      self.vector = matrix.col(vector)
+    class TransformVisitor(object):
+        def __init__(self, vector):
+            self.vector = matrix.col(vector)
 
-    def __call__(self, nx_file, depends_on):
-      from scitbx import matrix
-      item = nx_file[depends_on]
-      value = item[()]
-      units = item.attrs['units']
-      ttype = item.attrs['transformation_type']
-      vector = matrix.col(item.attrs['vector'])
-      if ttype == 'translation':
-        value = convert_units(value, units, 'mm')
-        self.vector = vector * value + self.vector
-      elif ttype == 'rotation':
-        if units == 'rad':
-          deg = False
-        elif units == 'deg':
-          deg = True
-        else:
-          raise RuntimeError('Invalid units: %s' % units)
-        self.vector.rotate(axis=vector, angle=value, deg=deg)
-      else:
-        raise RuntimeError('Unknown transformation_type: %s' % ttype)
+        def __call__(self, nx_file, depends_on):
+            from scitbx import matrix
+            item = nx_file[depends_on]
+            value = item[()]
+            units = item.attrs['units']
+            ttype = item.attrs['transformation_type']
+            vector = matrix.col(item.attrs['vector'])
+            if ttype == 'translation':
+                value = convert_units(value, units, 'mm')
+                self.vector = vector * value + self.vector
+            elif ttype == 'rotation':
+                if units == 'rad':
+                    deg = False
+                elif units == 'deg':
+                    deg = True
+                else:
+                    raise RuntimeError('Invalid units: %s' % units)
+                self.vector.rotate(axis=vector, angle=value, deg=deg)
+            else:
+                raise RuntimeError('Unknown transformation_type: %s' % ttype)
 
-    def result(self):
-      return self.vector
+        def result(self):
+            return self.vector
 
-  if vector is None:
-    value = nx_file[item][()]
-    units = nx_file[item].attrs['units']
-    ttype = nx_file[item].attrs['transformation_type']
-    vector = nx_file[item].attrs['vector']
-    if ttype == 'translation':
-      value = convert_units(value, units, "mm")
-      vector = vector * value
-  else:
-    pass
-  visitor = TransformVisitor(vector)
+    if vector is None:
+        value = nx_file[item][()]
+        units = nx_file[item].attrs['units']
+        ttype = nx_file[item].attrs['transformation_type']
+        vector = nx_file[item].attrs['vector']
+        if ttype == 'translation':
+            value = convert_units(value, units, "mm")
+            vector = vector * value
+    else:
+        pass
+    visitor = TransformVisitor(vector)
 
-  visit_dependancies(nx_file, item, visitor)
+    visit_dependancies(nx_file, item, visitor)
 
-  return visitor.result()
+    return visitor.result()
 
 
 def run_checks(handle, items):
-  '''
-  Run checks for datasets
+    '''
+    Run checks for datasets
 
-  '''
-  from os.path import join
-  for item, detail in items.iteritems():
-    min_occurs = detail["minOccurs"]
-    checks = detail['checks']
-    assert(min_occurs in [0, 1])
-    try:
-      dset = handle[item]
-    except Exception:
-      dset = None
-      if min_occurs != 0:
-        raise RuntimeError('Could not find %s in %s' % (item, handle.name))
-      else:
-        continue
-    if dset is not None:
-      for check in checks:
-        check(dset)
+    '''
+    from os.path import join
+    for item, detail in items.iteritems():
+        min_occurs = detail["minOccurs"]
+        checks = detail['checks']
+        assert (min_occurs in [0, 1])
+        try:
+            dset = handle[item]
+        except Exception:
+            dset = None
+            if min_occurs != 0:
+                raise RuntimeError('Could not find %s in %s' % (item, handle.name))
+            else:
+                continue
+        if dset is not None:
+            for check in checks:
+                check(dset)
 
 
 class NXdetector_module(object):
-  '''
-  A class to hold a handle to NXdetector_module
+    '''
+    A class to hold a handle to NXdetector_module
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
+    def __init__(self, handle, errors=None):
+        self.handle = handle
 
-    self.handle = handle
+        items = {
+            "data_origin": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["uint32", "uint64", "int32", "int64"], shape=(2,))
+                ]
+            },
+            "data_size": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["int32", "int64", "uint32", "uint64"], shape=(2,))
+                ]
+            },
+            "module_offset": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["float64", "float32", "int64", "int32"], is_scalar=True),
+                    check_attr("transformation_type"),
+                    check_attr("vector"),
+                    check_attr("offset"),
+                    check_attr("units", dtype=str),
+                    check_attr("depends_on")
+                ]
+            },
+            "fast_pixel_direction": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True),
+                    check_attr("transformation_type"),
+                    check_attr("vector"),
+                    check_attr("offset"),
+                    check_attr("units", dtype=str),
+                    check_attr("depends_on")
+                ]
+            },
+            "slow_pixel_direction": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True),
+                    check_attr("transformation_type"),
+                    check_attr("vector"),
+                    check_attr("offset"),
+                    check_attr("units", dtype=str),
+                    check_attr("depends_on"),
+                ]
+            },
+        }
 
-    items = {
-      "data_origin" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["uint32", "uint64", "int32", "int64"], shape=(2,))
-        ]
-      },
-      "data_size" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["int32", "int64", "uint32", "uint64"], shape=(2,))
-        ]
-      },
-      "module_offset" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["float64", "float32", "int64", "int32"], is_scalar=True),
-          check_attr("transformation_type"),
-          check_attr("vector"),
-          check_attr("offset"),
-          check_attr("units", dtype=str),
-          check_attr("depends_on")
-        ]
-      },
-      "fast_pixel_direction" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True),
-          check_attr("transformation_type"),
-          check_attr("vector"),
-          check_attr("offset"),
-          check_attr("units", dtype=str),
-          check_attr("depends_on")
-        ]
-      },
-      "slow_pixel_direction" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True),
-          check_attr("transformation_type"),
-          check_attr("vector"),
-          check_attr("offset"),
-          check_attr("units", dtype=str),
-          check_attr("depends_on"),
-        ]
-      },
-    }
-
-    run_checks(self.handle, items)
-
+        run_checks(self.handle, items)
 
 
 class NXdetector(object):
-  '''
-  A class to handle a handle to NXdetector
+    '''
+    A class to handle a handle to NXdetector
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
+    def __init__(self, handle, errors=None):
 
-    self.handle = handle
+        self.handle = handle
 
-    # The items to validate
-    items = {
-      "depends_on" : {
-        "minOccurs" : 1,
-        "checks" : []
-      },
-      "data" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dims=3)
-        ]
-      },
-      "description" : {
-        "minOccurs" : 1,
-        "checks" : []
-      },
-      "time_per_channel" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "distance" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True)
-        ]
-      },
-      "dead_time" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True)
-        ]
-      },
-      "count_time" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True)
-        ]
-      },
-      "beam_centre_x" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True)
-        ]
-      },
-      "beam_centre_y" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True)
-        ]
-      },
-      "angular_calibration_applied" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
-        ]
-      },
-      "angular_calibration" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"])
-        ]
-      },
-      "flatfield_applied" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
-        ]
-      },
-      "flatfield" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"])
-        ]
-      },
-      "flatfield_error" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"])
-        ]
-      },
-      "pixel_mask_applied" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
-        ]
-      },
-      "pixel_mask" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype="int32")
-        ]
-      },
-      "countrate_correction_applied" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
-        ]
-      },
-      "bit_depth_readout" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['int32', "int64"], is_scalar=True)
-        ]
-      },
-      "detector_readout_time" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['float32', "float64"], is_scalar=True)
-        ]
-      },
-      "frame_time" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['float32', "float64"], is_scalar=True)
-        ]
-      },
-      "gain_setting" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "saturation_value" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["int32", "int64"], is_scalar=True)
-        ]
-      },
-      "sensor_material" : {
-        "minOccurs" : 1,
-        "checks" : []
-      },
-      "sensor_thickness" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True),
-          check_attr("units", dtype=str)
-        ]
-      },
-      "threshold_energy" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=['float32', "float64"], is_scalar=True)
-        ]
-      },
-      "type" : {
-        "minOccurs" : 1,
-        "checks" : []
-      },
-    }
+        # The items to validate
+        items = {
+            "depends_on": {
+                "minOccurs": 1,
+                "checks": []
+            },
+            "data": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dims=3)
+                ]
+            },
+            "description": {
+                "minOccurs": 1,
+                "checks": []
+            },
+            "time_per_channel": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "distance": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True)
+                ]
+            },
+            "dead_time": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True)
+                ]
+            },
+            "count_time": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True)
+                ]
+            },
+            "beam_centre_x": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True)
+                ]
+            },
+            "beam_centre_y": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True)
+                ]
+            },
+            "angular_calibration_applied": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
+                ]
+            },
+            "angular_calibration": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"])
+                ]
+            },
+            "flatfield_applied": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
+                ]
+            },
+            "flatfield": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"])
+                ]
+            },
+            "flatfield_error": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"])
+                ]
+            },
+            "pixel_mask_applied": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
+                ]
+            },
+            "pixel_mask": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype="int32")
+                ]
+            },
+            "countrate_correction_applied": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['int32', 'int64', 'uint32', 'uint64'], is_scalar=True)
+                ]
+            },
+            "bit_depth_readout": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['int32', "int64"], is_scalar=True)
+                ]
+            },
+            "detector_readout_time": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['float32', "float64"], is_scalar=True)
+                ]
+            },
+            "frame_time": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['float32', "float64"], is_scalar=True)
+                ]
+            },
+            "gain_setting": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "saturation_value": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["int32", "int64"], is_scalar=True)
+                ]
+            },
+            "sensor_material": {
+                "minOccurs": 1,
+                "checks": []
+            },
+            "sensor_thickness": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True),
+                    check_attr("units", dtype=str)
+                ]
+            },
+            "threshold_energy": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=['float32', "float64"], is_scalar=True)
+                ]
+            },
+            "type": {
+                "minOccurs": 1,
+                "checks": []
+            },
+        }
 
-    run_checks(self.handle, items)
+        run_checks(self.handle, items)
 
-    # Find the NXdetector_modules
-    self.modules = []
-    for entry in find_class(self.handle, "NXdetector_module"):
-      try:
-        self.modules.append(NXdetector_module(entry, errors=errors))
-      except Exception, e:
-        if errors is not None:
-          errors.append(str(e))
+        # Find the NXdetector_modules
+        self.modules = []
+        for entry in find_class(self.handle, "NXdetector_module"):
+            try:
+                self.modules.append(NXdetector_module(entry, errors=errors))
+            except Exception, e:
+                if errors is not None:
+                    errors.append(str(e))
 
-    # Check we've got some stuff
-    if len(self.modules) == 0:
-      raise RuntimeError('No NXdetector_module in %s' % self.handle.name)
+        # Check we've got some stuff
+        if len(self.modules) == 0:
+            raise RuntimeError('No NXdetector_module in %s' % self.handle.name)
 
 
 class NXinstrument(object):
-  '''
-  A class to hold a handle to NXinstrument
+    '''
+    A class to hold a handle to NXinstrument
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
+    def __init__(self, handle, errors=None):
 
-    self.handle = handle
+        self.handle = handle
 
-    # Find the NXdetector
-    self.detectors = []
-    for entry in find_class(self.handle, "NXdetector"):
-      try:
-        self.detectors.append(NXdetector(entry, errors=errors))
-      except Exception, e:
-        if errors is not None:
-          errors.append(str(e))
+        # Find the NXdetector
+        self.detectors = []
+        for entry in find_class(self.handle, "NXdetector"):
+            try:
+                self.detectors.append(NXdetector(entry, errors=errors))
+            except Exception, e:
+                if errors is not None:
+                    errors.append(str(e))
 
-    # Check we've got stuff
-    if len(self.detectors) == 0:
-      raise RuntimeError('No NXdetector in %s' % self.handle.name)
+        # Check we've got stuff
+        if len(self.detectors) == 0:
+            raise RuntimeError('No NXdetector in %s' % self.handle.name)
 
 
 class NXbeam(object):
-  '''
-  A class to hold a handle to NXbeam
+    '''
+    A class to hold a handle to NXbeam
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
+    def __init__(self, handle, errors=None):
+        self.handle = handle
 
-    self.handle = handle
+        items = {
+            "incident_wavelength": {
+                "minOccurs": 1,
+                "checks": [
+                    check_dset(dtype=['float32', "float64"], is_scalar=True)
+                ]
+            },
+            "incident_wavelength_spectrum": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "incident_polarization_stokes": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], shape=(4,))
+                ]
+            },
+            "flux": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype=["float32", "float64"], is_scalar=True)
+                ]
+            },
+        }
 
-    items = {
-      "incident_wavelength" : {
-        "minOccurs" : 1,
-        "checks" : [
-          check_dset(dtype=['float32', "float64"], is_scalar=True)
-        ]
-      },
-      "incident_wavelength_spectrum" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "incident_polarization_stokes" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], shape=(4,))
-        ]
-      },
-      "flux" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype=["float32", "float64"], is_scalar=True)
-        ]
-      },
-    }
-
-    run_checks(self.handle, items)
+        run_checks(self.handle, items)
 
 
 class NXsample(object):
-  '''
-  A class to hold a handle to NXsample
+    '''
+    A class to hold a handle to NXsample
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
+    def __init__(self, handle, errors=None):
 
-    self.handle = handle
+        self.handle = handle
 
-    items = {
-      "name" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "depends_on" : {
-        "minOccurs" : 1,
-        "checks" : []
-      },
-      "chemical_formula" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "unit_cell" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype="float64", dims=2)
-        ]
-      },
-      "unit_cell_class" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "unit_cell_group" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "sample_orientation" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype="float64", shape=(3,))
-        ]
-      },
-      "orientation_matrix" : {
-        "minOccurs" : 0,
-        "checks" : [
-          check_dset(dtype="float64", dims=3)
-        ]
-      },
-      "temperature" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-    }
+        items = {
+            "name": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "depends_on": {
+                "minOccurs": 1,
+                "checks": []
+            },
+            "chemical_formula": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "unit_cell": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype="float64", dims=2)
+                ]
+            },
+            "unit_cell_class": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "unit_cell_group": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "sample_orientation": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype="float64", shape=(3,))
+                ]
+            },
+            "orientation_matrix": {
+                "minOccurs": 0,
+                "checks": [
+                    check_dset(dtype="float64", dims=3)
+                ]
+            },
+            "temperature": {
+                "minOccurs": 0,
+                "checks": []
+            },
+        }
 
-    run_checks(self.handle, items)
+        run_checks(self.handle, items)
 
-    # Find the NXsource
-    self.beams = []
-    for entry in find_class(self.handle, "NXbeam"):
-      try:
-        self.beams.append(NXbeam(entry, errors=errors))
-      except Exception, e:
-        if errors is not None:
-          errors.append(str(e))
+        # Find the NXsource
+        self.beams = []
+        for entry in find_class(self.handle, "NXbeam"):
+            try:
+                self.beams.append(NXbeam(entry, errors=errors))
+            except Exception, e:
+                if errors is not None:
+                    errors.append(str(e))
 
-    # Check we've got stuff
-    if len(self.beams) == 0:
-      raise RuntimeError('No NXbeam in %s' % self.handle.name)
+        # Check we've got stuff
+        if len(self.beams) == 0:
+            raise RuntimeError('No NXbeam in %s' % self.handle.name)
 
 
 class NXdata(object):
-  '''
-  A class to hold a handle to NXdata
+    '''
+    A class to hold a handle to NXdata
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
-
-    self.handle = handle
+    def __init__(self, handle, errors=None):
+        self.handle = handle
 
 
 class NXmxEntry(object):
-  '''
-  A class to hold a handle to NXmx entries
+    '''
+    A class to hold a handle to NXmx entries
 
-  '''
+    '''
 
-  def __init__(self, handle, errors=None):
+    def __init__(self, handle, errors=None):
 
-    self.handle = handle
+        self.handle = handle
 
-    items = {
-      'title' : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "start_time" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-      "end_time" : {
-        "minOccurs" : 0,
-        "checks" : []
-      },
-    }
+        items = {
+            'title': {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "start_time": {
+                "minOccurs": 0,
+                "checks": []
+            },
+            "end_time": {
+                "minOccurs": 0,
+                "checks": []
+            },
+        }
 
-    run_checks(self.handle, items)
+        run_checks(self.handle, items)
 
-    # Find the NXinstrument
-    self.instruments = []
-    for entry in find_class(self.handle, "NXinstrument"):
-      try:
-        self.instruments.append(NXinstrument(entry, errors=errors))
-      except Exception, e:
-        if errors is not None:
-          errors.append(str(e))
+        # Find the NXinstrument
+        self.instruments = []
+        for entry in find_class(self.handle, "NXinstrument"):
+            try:
+                self.instruments.append(NXinstrument(entry, errors=errors))
+            except Exception, e:
+                if errors is not None:
+                    errors.append(str(e))
 
-    # Find the NXsample
-    self.samples = []
-    for entry in find_class(self.handle, "NXsample"):
-      try:
-        self.samples.append(NXsample(entry, errors=errors))
-      except Exception, e:
-        if errors is not None:
-          errors.append(str(e))
+        # Find the NXsample
+        self.samples = []
+        for entry in find_class(self.handle, "NXsample"):
+            try:
+                self.samples.append(NXsample(entry, errors=errors))
+            except Exception, e:
+                if errors is not None:
+                    errors.append(str(e))
 
-    # Find the NXidata
-    self.data = []
-    for entry in find_class(self.handle, "NXdata"):
-      try:
-        self.data.append(NXdata(entry, errors=errors))
-      except Exception, e:
-        if errors is not None:
-          errors.append(str(e))
+        # Find the NXidata
+        self.data = []
+        for entry in find_class(self.handle, "NXdata"):
+            try:
+                self.data.append(NXdata(entry, errors=errors))
+            except Exception, e:
+                if errors is not None:
+                    errors.append(str(e))
 
-    # Check we've got some stuff
-    if len(self.instruments) == 0:
-      raise RuntimeError('No NXinstrument in %s' % self.handle.name)
-    if len(self.samples) == 0:
-      raise RuntimeError('No NXsample in %s' % self.handle.name)
-    if len(self.data) == 0:
-      raise RuntimeError('No NXdata in %s' % self.handle.name)
+        # Check we've got some stuff
+        if len(self.instruments) == 0:
+            raise RuntimeError('No NXinstrument in %s' % self.handle.name)
+        if len(self.samples) == 0:
+            raise RuntimeError('No NXsample in %s' % self.handle.name)
+        if len(self.data) == 0:
+            raise RuntimeError('No NXdata in %s' % self.handle.name)
 
 
 def validate(nx_file, item, test):
-  '''
-  Validate the NXmx entries
+    '''
+    Validate the NXmx entries
 
-  '''
-  values = []
-  fails = []
-  context = {}
-  test(context, nx_file, item, values, fails)
-  if len(fails) > 0:
-    raise AssertionError('\n'.join(fails))
-  return values
+    '''
+    values = []
+    fails = []
+    context = {}
+    test(context, nx_file, item, values, fails)
+    if len(fails) > 0:
+        raise AssertionError('\n'.join(fails))
+    return values
+
 
 def check_path(nx_file, path):
-  '''
-  Ensure path exists
+    '''
+    Ensure path exists
 
-  '''
-  section = nx_file
-  try:
-    nx_file[path]
-  except Exception:
-    return False
-  return True
+    '''
+    section = nx_file
+    try:
+        nx_file[path]
+    except Exception:
+        return False
+    return True
+
 
 class recipe:
-  """
-  Recipe to validate files with the NXmx feature
+    """
+    Recipe to validate files with the NXmx feature
 
-  """
+    """
 
-  def __init__(self, filedesc, entrypath):
-    self.file = filedesc
-    self.entry = entrypath
-    self.title = "NXmx"
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "NXmx"
 
-  def process(self):
-    # A list of errors
-    self.errors = []
+    def process(self):
+        # A list of errors
+        self.errors = []
 
-    # Find the NXmx entries
-    self.entries = []
-    for entry in find_entries(self.file, "/"):
-      try:
-        self.entries.append(NXmxEntry(entry, errors=self.errors))
-      except Exception, e:
-        self.errors.append(str(e))
+        # Find the NXmx entries
+        self.entries = []
+        for entry in find_entries(self.file, "/"):
+            try:
+                self.entries.append(NXmxEntry(entry, errors=self.errors))
+            except Exception, e:
+                self.errors.append(str(e))
 
-    # Check we've got some stuff
-    if len(self.entries) == 0:
-      raise RuntimeError('''
+        # Check we've got some stuff
+        if len(self.entries) == 0:
+            raise RuntimeError('''
         Error reading NXmxfile: %s
           No NXmx entries in file
 
@@ -812,10 +816,10 @@ class recipe:
 
 
 if __name__ == '__main__':
-  import sys
-  import h5py
+    import sys
+    import h5py
 
-  handle = h5py.File(sys.argv[1])
+    handle = h5py.File(sys.argv[1])
 
-  r = recipe(handle, '/')
-  r.process()
+    r = recipe(handle, '/')
+    r.process()

--- a/src/recipes/0000000000000007/recipe.py
+++ b/src/recipes/0000000000000007/recipe.py
@@ -1,5 +1,5 @@
 def check_len(context, entry, item, values, fails):
-    frames = entry[item].shape[0];
+    frames = entry[item].shape[0]
     if ('nFrames' not in context.keys()) and frames != 1:
         context['nFrames'] = frames
         context['nFrames_item'] = item

--- a/src/recipes/0000000000000007/recipe.py
+++ b/src/recipes/0000000000000007/recipe.py
@@ -1,129 +1,141 @@
 def check_len(context, entry, item, values, fails):
-  frames = entry[item].shape[0];
-  if (not 'nFrames' in context.keys()) and frames != 1:
-    context['nFrames'] = frames
-    context['nFrames_item'] = item
-  else :
-    if not frames in [context['nFrames'], 1]:
-      fails.append("'%s' does not have the same number of frames as '%s'" % (item, context['nFrames_item']))
+    frames = entry[item].shape[0];
+    if (not 'nFrames' in context.keys()) and frames != 1:
+        context['nFrames'] = frames
+        context['nFrames_item'] = item
+    else:
+        if not frames in [context['nFrames'], 1]:
+            fails.append("'%s' does not have the same number of frames as '%s'" % (item, context['nFrames_item']))
+
 
 def check_int(context, entry, item, value, fails):
-  dtype = entry[item].dtype
-  if not dtype in ["int64"]:
-    fails.append("'%s' is of type %s, expected int32 or int64" % (item, dtype))
+    dtype = entry[item].dtype
+    if not dtype in ["int64"]:
+        fails.append("'%s' is of type %s, expected int32 or int64" % (item, dtype))
+
 
 def check_bool(context, entry, item, value, fails):
-  dtype = entry[item].dtype
-  if not dtype in ["bool"]:
-    fails.append("'%s' is of type %s, expected bool" % (item, dtype))
+    dtype = entry[item].dtype
+    if not dtype in ["bool"]:
+        fails.append("'%s' is of type %s, expected bool" % (item, dtype))
+
 
 def check_uint(context, entry, item, value, fails):
-  dtype = entry[item].dtype
-  if not dtype in ["uint64"]:
-    fails.append("'%s' is of type %s, expected uint64" % (item, dtype))
+    dtype = entry[item].dtype
+    if not dtype in ["uint64"]:
+        fails.append("'%s' is of type %s, expected uint64" % (item, dtype))
+
 
 def check_float(context, entry, item, value, fails):
-  dtype = entry[item].dtype
-  if not dtype in [ "float64"]:
-    fails.append("'%s' is of type %s, expected float64" % (item, dtype))
+    dtype = entry[item].dtype
+    if not dtype in ["float64"]:
+        fails.append("'%s' is of type %s, expected float64" % (item, dtype))
+
 
 def check_array_uint(context, entry, item, value, fails):
-  dtype = entry[item].dtype
-  if not dtype in ["object"]:
-    fails.append("'%s' is of type %s, expected object" % (item, dtype))
+    dtype = entry[item].dtype
+    if not dtype in ["object"]:
+        fails.append("'%s' is of type %s, expected object" % (item, dtype))
+
 
 VALIDATE = {
-  "h"             : (False, [check_len, check_int]),
-  "k"             : (False, [check_len, check_int]),
-  "l"             : (False, [check_len, check_int]),
-  "id"            : (False, [check_len, check_uint]),
-  "reflection_id" : (False, [check_len, check_uint]),
-  "entering"      : (False, [check_len, check_bool]),
-  "det_module"    : (False, [check_len, check_uint]),
-  "flags"         : (False, [check_len, check_uint]),
-  "d"             : (False, [check_len, check_float]),
-  "partiality"    : (False, [check_len, check_float]),
-  "prd_frame"     : (False, [check_len, check_float]),
-  "prd_mm_x"      : (False, [check_len, check_float]),
-  "prd_mm_y"      : (False, [check_len, check_float]),
-  "prd_phi"       : (False, [check_len, check_float]),
-  "prd_px_x"      : (False, [check_len, check_float]),
-  "prd_px_y"      : (False, [check_len, check_float]),
-  "obs_frame_val" : (False, [check_len, check_float]),
-  "obs_frame_var" : (False, [check_len, check_float]),
-  "obs_px_x_val"  : (False, [check_len, check_float]),
-  "obs_px_x_var"  : (False, [check_len, check_float]),
-  "obs_px_y_val"  : (False, [check_len, check_float]),
-  "obs_px_y_var"  : (False, [check_len, check_float]),
-  "obs_phi_val"   : (False, [check_len, check_float]),
-  "obs_phi_var"   : (False, [check_len, check_float]),
-  "obs_mm_x_val"  : (False, [check_len, check_float]),
-  "obs_mm_x_var"  : (False, [check_len, check_float]),
-  "obs_mm_y_val"  : (False, [check_len, check_float]),
-  "obs_mm_y_var"  : (False, [check_len, check_float]),
-  "bbx0"          : (False, [check_len, check_int]),
-  "bbx1"          : (False, [check_len, check_int]),
-  "bby0"          : (False, [check_len, check_int]),
-  "bby1"          : (False, [check_len, check_int]),
-  "bbz0"          : (False, [check_len, check_int]),
-  "bbz1"          : (False, [check_len, check_int]),
-  "bkg_mean"      : (False, [check_len, check_float]),
-  "int_prf_val"   : (True,  [check_len, check_float]),
-  "int_prf_var"   : (True,  [check_len, check_float]),
-  "int_sum_val"   : (False, [check_len, check_float]),
-  "int_sum_var"   : (False, [check_len, check_float]),
-  "lp"            : (False, [check_len, check_float]),
-  "prf_cc"        : (True,  [check_len, check_float]),
-  "overlaps"      : (True,  [check_len, check_array_uint]),
+    "h": (False, [check_len, check_int]),
+    "k": (False, [check_len, check_int]),
+    "l": (False, [check_len, check_int]),
+    "id": (False, [check_len, check_uint]),
+    "reflection_id": (False, [check_len, check_uint]),
+    "entering": (False, [check_len, check_bool]),
+    "det_module": (False, [check_len, check_uint]),
+    "flags": (False, [check_len, check_uint]),
+    "d": (False, [check_len, check_float]),
+    "partiality": (False, [check_len, check_float]),
+    "prd_frame": (False, [check_len, check_float]),
+    "prd_mm_x": (False, [check_len, check_float]),
+    "prd_mm_y": (False, [check_len, check_float]),
+    "prd_phi": (False, [check_len, check_float]),
+    "prd_px_x": (False, [check_len, check_float]),
+    "prd_px_y": (False, [check_len, check_float]),
+    "obs_frame_val": (False, [check_len, check_float]),
+    "obs_frame_var": (False, [check_len, check_float]),
+    "obs_px_x_val": (False, [check_len, check_float]),
+    "obs_px_x_var": (False, [check_len, check_float]),
+    "obs_px_y_val": (False, [check_len, check_float]),
+    "obs_px_y_var": (False, [check_len, check_float]),
+    "obs_phi_val": (False, [check_len, check_float]),
+    "obs_phi_var": (False, [check_len, check_float]),
+    "obs_mm_x_val": (False, [check_len, check_float]),
+    "obs_mm_x_var": (False, [check_len, check_float]),
+    "obs_mm_y_val": (False, [check_len, check_float]),
+    "obs_mm_y_var": (False, [check_len, check_float]),
+    "bbx0": (False, [check_len, check_int]),
+    "bbx1": (False, [check_len, check_int]),
+    "bby0": (False, [check_len, check_int]),
+    "bby1": (False, [check_len, check_int]),
+    "bbz0": (False, [check_len, check_int]),
+    "bbz1": (False, [check_len, check_int]),
+    "bkg_mean": (False, [check_len, check_float]),
+    "int_prf_val": (True, [check_len, check_float]),
+    "int_prf_var": (True, [check_len, check_float]),
+    "int_sum_val": (False, [check_len, check_float]),
+    "int_sum_var": (False, [check_len, check_float]),
+    "lp": (False, [check_len, check_float]),
+    "prf_cc": (True, [check_len, check_float]),
+    "overlaps": (True, [check_len, check_array_uint]),
 }
 
+
 def find_nx_diffraction_entries(nx_file, entry):
-  hits = []
-  def visitor(name, obj):
-    if "NX_class" in obj.attrs.keys():
-      if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
-        if "definition" in obj.keys():
-          if obj["definition"].value == "NXdiffraction":
-            hits.append(obj)
-  nx_file[entry].visititems(visitor)
-  return hits
+    hits = []
+
+    def visitor(name, obj):
+        if "NX_class" in obj.attrs.keys():
+            if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
+                if "definition" in obj.keys():
+                    if obj["definition"].value == "NXdiffraction":
+                        hits.append(obj)
+
+    nx_file[entry].visititems(visitor)
+    return hits
+
 
 def check_path(entry, path):
-  section = entry
-  for part in path.split('/'):
-    if part in section.keys():
-      section = section[part]
-    else :
-      return False
-  return True
+    section = entry
+    for part in path.split('/'):
+        if part in section.keys():
+            section = section[part]
+        else:
+            return False
+    return True
+
 
 def validate(entry):
-  context = {}
-  values = {}
-  fails = []
-  for item, (optional, tests) in VALIDATE.iteritems():
-    if check_path(entry, item):
-      for test in tests:
-        test(context, entry, item, values, fails)
-    elif not optional:
-      fails.append("'NXdiffraction/%s' is missing from the NXdiffraction entry" % (item))
-  if len(fails) > 0:
-    raise AssertionError('\n'.join(fails))
-  return values
+    context = {}
+    values = {}
+    fails = []
+    for item, (optional, tests) in VALIDATE.iteritems():
+        if check_path(entry, item):
+            for test in tests:
+                test(context, entry, item, values, fails)
+        elif not optional:
+            fails.append("'NXdiffraction/%s' is missing from the NXdiffraction entry" % (item))
+    if len(fails) > 0:
+        raise AssertionError('\n'.join(fails))
+    return values
+
 
 class recipe:
-  """
-  Recipe to validate files with the NXdiffraction feature
-  
-  """
+    """
+    Recipe to validate files with the NXdiffraction feature
 
-  def __init__(self, filedesc, entrypath):
-    self.file = filedesc
-    self.entry = entrypath
-    self.title = "NXdiffraction"
+    """
 
-  def process(self):
-    entries = find_nx_diffraction_entries(self.file, self.entry)
-    if len(entries) == 0:
-      raise AssertionError('No NXdiffraction entries found')
-    return map(validate, entries)
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "NXdiffraction"
+
+    def process(self):
+        entries = find_nx_diffraction_entries(self.file, self.entry)
+        if len(entries) == 0:
+            raise AssertionError('No NXdiffraction entries found')
+        return map(validate, entries)

--- a/src/recipes/0000000000000007/recipe.py
+++ b/src/recipes/0000000000000007/recipe.py
@@ -1,40 +1,40 @@
 def check_len(context, entry, item, values, fails):
     frames = entry[item].shape[0];
-    if (not 'nFrames' in context.keys()) and frames != 1:
+    if ('nFrames' not in context.keys()) and frames != 1:
         context['nFrames'] = frames
         context['nFrames_item'] = item
     else:
-        if not frames in [context['nFrames'], 1]:
+        if frames not in [context['nFrames'], 1]:
             fails.append("'%s' does not have the same number of frames as '%s'" % (item, context['nFrames_item']))
 
 
 def check_int(context, entry, item, value, fails):
     dtype = entry[item].dtype
-    if not dtype in ["int64"]:
+    if dtype not in ["int64"]:
         fails.append("'%s' is of type %s, expected int32 or int64" % (item, dtype))
 
 
 def check_bool(context, entry, item, value, fails):
     dtype = entry[item].dtype
-    if not dtype in ["bool"]:
+    if dtype not in ["bool"]:
         fails.append("'%s' is of type %s, expected bool" % (item, dtype))
 
 
 def check_uint(context, entry, item, value, fails):
     dtype = entry[item].dtype
-    if not dtype in ["uint64"]:
+    if dtype not in ["uint64"]:
         fails.append("'%s' is of type %s, expected uint64" % (item, dtype))
 
 
 def check_float(context, entry, item, value, fails):
     dtype = entry[item].dtype
-    if not dtype in ["float64"]:
+    if dtype not in ["float64"]:
         fails.append("'%s' is of type %s, expected float64" % (item, dtype))
 
 
 def check_array_uint(context, entry, item, value, fails):
     dtype = entry[item].dtype
-    if not dtype in ["object"]:
+    if dtype not in ["object"]:
         fails.append("'%s' is of type %s, expected object" % (item, dtype))
 
 

--- a/src/recipes/C0FFEEBEEFC0FFEE/recipe.py
+++ b/src/recipes/C0FFEEBEEFC0FFEE/recipe.py
@@ -1,45 +1,42 @@
-#
-
 class recipe:
-	"""
-		A demo recipe for finding the information associated with this demo feature.
-		
-		This is meant to help consumers of this feature to understand how to implement 
-		code that understands that feature (copy and paste of the code is allowed).
-		It also documents in what preference order (if any) certain things are evaluated
-		when finding the information.
-	"""
+    """
+        A demo recipe for finding the information associated with this demo feature.
 
-	def __init__(self, filedesc, entrypath):
-		self.file = filedesc
-		self.entry = entrypath
-		self.title = "CIF-style sample geometry"
+        This is meant to help consumers of this feature to understand how to implement
+        code that understands that feature (copy and paste of the code is allowed).
+        It also documents in what preference order (if any) certain things are evaluated
+        when finding the information.
+    """
 
-	def findNXsample(self):
-		for node in self.file[self.entry].keys():
-			try:
-				absnode = "%s/%s" % (self.entry, node)
-				if self.file[absnode].attrs["NX_class"] == "NXsample":
-					return absnode
-			except:
-				pass
-		# better have custom exceptions
-		raise Exception("no NXsample found")
-		
-	def process(self):
-		dependency_chain = []
-		try:
-			sample = self.findNXsample()
-			# this may need more attention for reading all possible types of string
-			depends_on = self.file[sample+"/depends_on"][0]
-			while not depends_on == ".":
-				dependency_chain.append(depends_on)
-				# this may need more attention for reading all possible types of string
-				depends_on = self.file[depends_on].attrs["depends_on"]
-	
-		except Exception as e:
-			raise Exception("this feature does not validate correctly: "+e)
-			
-			# better have custom exceptions
-		return { "dependency_chain" : dependency_chain } 
-	
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "CIF-style sample geometry"
+
+    def findNXsample(self):
+        for node in self.file[self.entry].keys():
+            try:
+                absnode = "%s/%s" % (self.entry, node)
+                if self.file[absnode].attrs["NX_class"] == "NXsample":
+                    return absnode
+            except:
+                pass
+        # better have custom exceptions
+        raise Exception("no NXsample found")
+
+    def process(self):
+        dependency_chain = []
+        try:
+            sample = self.findNXsample()
+            # this may need more attention for reading all possible types of string
+            depends_on = self.file[sample + "/depends_on"][0]
+            while not depends_on == ".":
+                dependency_chain.append(depends_on)
+                # this may need more attention for reading all possible types of string
+                depends_on = self.file[depends_on].attrs["depends_on"]
+
+        except Exception as e:
+            raise Exception("this feature does not validate correctly: " + e)
+
+        # better have custom exceptions
+        return {"dependency_chain": dependency_chain}

--- a/src/recipes/D1A0000000000001/recipe.py
+++ b/src/recipes/D1A0000000000001/recipe.py
@@ -120,5 +120,4 @@ class recipe:
 
         if len(self.NXdatas) == 0:
             raise AssertionError('No NXdata with cansas Axis found\n' + '\n'.join(self.failure_comments))
-        a = self.NXdatas[0]
         return self.NXdatas

--- a/src/recipes/D1A0000000000001/recipe.py
+++ b/src/recipes/D1A0000000000001/recipe.py
@@ -1,10 +1,10 @@
 import numpy as np
 
+
 class NXDataWrapper:
-    
     def __init__(self, NXdata):
         self.name = NXdata.name
-        
+
         # get all the names of the datasets
         datasets = list(NXdata.keys())
 
@@ -21,7 +21,7 @@ class NXDataWrapper:
         # build indices dict
         self.indecies = {}
         for dataset in datasets:
-            self.indecies[dataset] = NXdata.attrs[dataset+"_indices"]
+            self.indecies[dataset] = NXdata.attrs[dataset + "_indices"]
 
         # now build a list of the primary axes
         self.primary_axes = []
@@ -44,7 +44,7 @@ class NXDataWrapper:
         return self.data.shape
 
     def get_axis_slice(self, name, slicelist, dataset):
-        slices = [slice(x,x+1) if type(x) is not slice else x for x in slicelist]
+        slices = [slice(x, x + 1) if type(x) is not slice else x for x in slicelist]
         indecies = self.indecies[name]
         reduced_slice = np.array(slices)[indecies]
         reduced_slice = tuple(reduced_slice)
@@ -70,8 +70,8 @@ class NXDataWrapper:
     def __repr__(self):
         return "%s (%s):: %s (%s)" % (self.name, self.signal, str(self.get_shape()), ','.join(self.primary_axes_names))
 
-class recipe:
 
+class recipe:
     """
     Recipe to describe if a file uses the cansas Axis format
     """
@@ -94,21 +94,24 @@ class recipe:
             return
         signal = obj.attrs['signal'][0]
         if signal not in datasets:
-            self.failure_comments.append("%s : Signal attribute points to a non-existent dataset (%s)" % (obj.name, signal))
+            self.failure_comments.append(
+                "%s : Signal attribute points to a non-existent dataset (%s)" % (obj.name, signal))
             return
         if "axes" not in attributes:
             self.failure_comments.append("%s : No 'axes' attribute is present" % (obj.name))
             return
         for axis in obj.attrs['axes']:
             if axis not in datasets + ['.']:
-                self.failure_comments.append("%s : Axis attribute points to a non-existent dataset (%s)" % (obj.name, axis))
+                self.failure_comments.append(
+                    "%s : Axis attribute points to a non-existent dataset (%s)" % (obj.name, axis))
                 return
         datasets.remove(signal)
         for dataset in datasets:
-            if dataset+"_indices" not in attributes:
-                self.failure_comments.append("%s : Axis dataset has no corresponding _indices attribute (%s)" % (obj.name, dataset))
+            if dataset + "_indices" not in attributes:
+                self.failure_comments.append(
+                    "%s : Axis dataset has no corresponding _indices attribute (%s)" % (obj.name, dataset))
                 return
-        
+
         self.NXdatas.append(NXDataWrapper(obj))
 
     def process(self):
@@ -116,8 +119,6 @@ class recipe:
         self.file[self.entry].visititems(self.visitor)
 
         if len(self.NXdatas) == 0:
-            raise AssertionError('No NXdata with cansas Axis found\n'+'\n'.join(self.failure_comments))
+            raise AssertionError('No NXdata with cansas Axis found\n' + '\n'.join(self.failure_comments))
         a = self.NXdatas[0]
         return self.NXdatas
-
-

--- a/src/recipes/D1A0000000000002/recipe.py
+++ b/src/recipes/D1A0000000000002/recipe.py
@@ -22,9 +22,10 @@ class NXcitation(object):
 
     def get_description_with_author(self):
         return "%s \\ref{%s}(%s, %s)" % (self.description,
-                                       self.get_bibtex_ref(),
-                                       self.get_first_author(),
-                                       self.get_date())
+                                         self.get_bibtex_ref(),
+                                         self.get_first_author(),
+                                         self.get_date())
+
 
 class NXcitation_manager(object):
     def __init__(self):
@@ -44,11 +45,11 @@ class NXcitation_manager(object):
 
     def __str__(self):
         return "\nDESCRIPTION\n%s\n\nBIBTEX\n%s\n\nENDNOTE\n%s" % (self.get_description_with_citations(),
-                                   self.get_full_bibtex(),
-                                   self.get_full_endnote())
+                                                                   self.get_full_bibtex(),
+                                                                   self.get_full_endnote())
+
 
 class NXciteVisitor(object):
-
     def __init__(self):
         self.citation_manager = NXcitation_manager()
 
@@ -58,7 +59,7 @@ class NXciteVisitor(object):
                 citation = NXcitation(obj['description'][0],
                                       obj['doi'][0],
                                       obj['endnote'][0],
-                                      obj['bibtex'][0]) 
+                                      obj['bibtex'][0])
                 self.citation_manager.add_citation(citation)
 
     def get_citation_manager(self, nx_file, entry):

--- a/src/recipes/D1A0000000000002/recipe.py
+++ b/src/recipes/D1A0000000000002/recipe.py
@@ -71,7 +71,7 @@ class recipe:
     """
         A demo recipe for finding the information associated with this demo feature.
 
-        This is meant to help consumers of this feature to understand how to implement 
+        This is meant to help consumers of this feature to understand how to implement
         code that understands that feature (copy and paste of the code is allowed).
         It also documents in what preference order (if any) certain things are evaluated
         when finding the information.

--- a/src/recipes/EFC0FFEE40DB9C66/recipe.py
+++ b/src/recipes/EFC0FFEE40DB9C66/recipe.py
@@ -1,5 +1,3 @@
-#
-
 class recipe:
     """
         A demo recipe for finding the information associated with this demo feature.

--- a/src/recipes/EFC0FFEE40DB9C66/recipe.py
+++ b/src/recipes/EFC0FFEE40DB9C66/recipe.py
@@ -1,27 +1,26 @@
 #
 
 class recipe:
-	"""
-		A demo recipe for finding the information associated with this demo feature.
-		
-		This is meant to help consumers of this feature to understand how to implement 
-		code that understands that feature (copy and paste of the code is allowed).
-		It also documents in what preference order (if any) certain things are evaluated
-		when finding the information.
-	"""
+    """
+        A demo recipe for finding the information associated with this demo feature.
 
-	def __init__(self, filedesc, entrypath):
-		self.file = filedesc
-		self.entry = entrypath
-		self.title = "scan command available"
+        This is meant to help consumers of this feature to understand how to implement
+        code that understands that feature (copy and paste of the code is allowed).
+        It also documents in what preference order (if any) certain things are evaluated
+        when finding the information.
+    """
 
-	def process(self):
-		try:
-			scan_command = self.file[self.entry+"/scan_command"][0]
-	
-		except Exception as e:
-			raise Exception("this feature does not validate correctly: "+e)
-			
-			# better have custom exceptions
-		return { "scan_command" : scan_command } 
-	
+    def __init__(self, filedesc, entrypath):
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "scan command available"
+
+    def process(self):
+        try:
+            scan_command = self.file[self.entry + "/scan_command"][0]
+
+        except Exception as e:
+            raise Exception("this feature does not validate correctly: " + e)
+
+        # better have custom exceptions
+        return {"scan_command": scan_command}


### PR DESCRIPTION
These changes aim to improve readability and consistency by making the code conform to [PEP 8](https://www.python.org/dev/peps/pep-0008/), with the exception of E501 (79 character line length restriction) which is usually considered deprecated.

The code now passes [flake8](http://flake8.pycqa.org/en/latest/index.html#) with `flake8 --ignore=E501`.