### PR TITLE
Add recipe interface superclass

### DIFF
--- a/src/IRecipe.py
+++ b/src/IRecipe.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta, abstractmethod
 
 
-class SuperRecipe:
+class IRecipe:
     __metaclass__ = ABCMeta
     """
-    Recipes should implement this interface, but do not need to subclass SuperRecipe
+    Recipes should implement this interface, but do not need to subclass IRecipe
     """
 
     @abstractmethod
@@ -30,9 +30,9 @@ class SuperRecipe:
     def __subclasshook__(cls, C):
         """
         This method should not be implemented in a recipe
-        It allows recipes to be considered a subclass of SuperRecipe without them explicitly subclassing it
+        It allows recipes to be considered a subclass of IRecipe without them explicitly subclassing it
         """
-        if cls is SuperRecipe:
+        if cls is IRecipe:
             if "process" in dir(C):
                 return True
         return NotImplemented

--- a/src/SuperRecipe.py
+++ b/src/SuperRecipe.py
@@ -1,0 +1,39 @@
+from abc import ABCMeta, abstractmethod
+
+
+class SuperRecipe:
+    __metaclass__ = ABCMeta
+    """
+    Recipes should implement this interface, but do not need to subclass SuperRecipe
+    """
+
+    @abstractmethod
+    def __init__(self, filedesc, entrypath):
+        """
+        Recipes should implement this method with a descriptive self.title
+        :param filedesc:
+        :param entrypath:
+        """
+        self.file = filedesc
+        self.entry = entrypath
+        self.title = "Placeholder Title"
+
+    @abstractmethod
+    def process(self):
+        """
+        Recipes should implement this method to return ...
+        :return:
+        """
+        return dict()  # should return dict or list here? Or iterable...
+
+    @classmethod
+    def __subclasshook__(cls, C):
+        """
+        This method should not be implemented in a recipe
+        :param C:
+        :return:
+        """
+        if cls is SuperRecipe:
+            if "process" in dir(C):
+                return True
+        return NotImplemented

--- a/src/SuperRecipe.py
+++ b/src/SuperRecipe.py
@@ -11,8 +11,8 @@ class SuperRecipe:
     def __init__(self, filedesc, entrypath):
         """
         Recipes should implement this method with a descriptive self.title
-        :param filedesc:
-        :param entrypath:
+        :param filedesc: path of the NeXus file
+        :param entrypath: path of the feature's directory
         """
         self.file = filedesc
         self.entry = entrypath
@@ -21,17 +21,16 @@ class SuperRecipe:
     @abstractmethod
     def process(self):
         """
-        Recipes should implement this method to return ...
-        :return:
+        Recipes should implement this method to return information which is useful to a user
+        :return: results of processing this feature
         """
-        return dict()  # should return dict or list here? Or iterable...
+        pass
 
     @classmethod
     def __subclasshook__(cls, C):
         """
         This method should not be implemented in a recipe
-        :param C:
-        :return:
+        It allows recipes to be considered a subclass of SuperRecipe without them explicitly subclassing it
         """
         if cls is SuperRecipe:
             if "process" in dir(C):

--- a/src/nxfeature.py
+++ b/src/nxfeature.py
@@ -5,7 +5,7 @@ import numpy
 import importlib
 import sys
 import os
-from SuperRecipe import SuperRecipe
+from IRecipe import IRecipe
 
 RECIPIE_DIR = os.path.dirname(os.path.realpath(__file__)) + "/recipes"
 sys.path.append(RECIPIE_DIR)
@@ -23,7 +23,7 @@ class InsaneEntryWithFeatures:
     def feature_response(self, featureid):
         featuremodule = importlib.import_module("%016X.recipe" % featureid)
         r = featuremodule.recipe(self.nxsfile, self.entrypath)
-        if isinstance(r, SuperRecipe):
+        if isinstance(r, IRecipe):
             return r.process()
         else:
             raise Exception(

--- a/src/nxfeature.py
+++ b/src/nxfeature.py
@@ -5,9 +5,7 @@ import numpy
 import importlib
 import sys
 import os
-
-# print "%016X" % int("C0FFEEBEEFC0FFEE", 16)
-# feature = "C0FFEEBEEFC0FFEE"
+from SuperRecipe import SuperRecipe
 
 RECIPIE_DIR = os.path.dirname(os.path.realpath(__file__)) + "/recipes"
 sys.path.append(RECIPIE_DIR)
@@ -25,7 +23,11 @@ class InsaneEntryWithFeatures:
     def feature_response(self, featureid):
         featuremodule = importlib.import_module("%016X.recipe" % featureid)
         r = featuremodule.recipe(self.nxsfile, self.entrypath)
-        return r.process()
+        if isinstance(r, SuperRecipe):
+            return r.process()
+        else:
+            raise Exception(
+                "Recipe for feature ID " + str(featureid) + " does not have the correct interface for a recipe")
 
     def feature_title(self, featureid):
         featuremodule = importlib.import_module("%016X.recipe" % featureid)
@@ -33,36 +35,28 @@ class InsaneEntryWithFeatures:
         return r.title
 
 
-class InsaneFeatureDiscoverer:
-    def __init__(self, nxsfile):
+class FeatureDiscoverer:
+    def __init__(self, nxsfile, test_all):
         self.file = h5py.File(nxsfile, 'r')
+        self.test_all = test_all
 
     def entries(self):
         ent = []
+        path = RECIPIE_DIR
         for entry in self.file.keys():
-            path = "/%s/features" % entry
-            try:
+            if self.test_all:
+                features = [int(feature, 16) for feature in os.listdir(RECIPIE_DIR)]
+            else:
+                path = "/%s/features" % entry
                 features = self.file[path]
-                if features.dtype == numpy.dtype("uint64"):
-                    ent.append(InsaneEntryWithFeatures(self.file, entry, features))
-            except:
-                print "no features in " + path
-                pass
-        return ent
+                if features.dtype != numpy.dtype("uint64"):
+                    # Directory name not of correct form to be a feature, ignore and move on to next
+                    continue
 
-
-class AllFeatureDiscoverer:
-    def __init__(self, nxsfile):
-        self.file = h5py.File(nxsfile, 'r')
-
-    def entries(self):
-        ent = []
-        for entry in self.file.keys():
             try:
-                features = [int(feat, 16) for feat in os.listdir(RECIPIE_DIR)]
                 ent.append(InsaneEntryWithFeatures(self.file, entry, features))
             except:
-                print "no recipies in " + RECIPIE_DIR
+                print "no recipes in " + path
                 pass
         return ent
 
@@ -72,15 +66,12 @@ if __name__ == '__main__':
 
     usage = "%prog [options] nxs_file"
     parser = optparse.OptionParser(usage=usage)
-    parser.add_option("-t", "--test", dest="test", help="Test file against all recipies", action="store_true",
+    parser.add_option("-t", "--test", dest="test", help="Test file against all recipes", action="store_true",
                       default=False)
 
     (options, args) = parser.parse_args()
 
-    if options.test:
-        disco = AllFeatureDiscoverer(args[0])
-    else:
-        disco = InsaneFeatureDiscoverer(args[0])
+    disco = FeatureDiscoverer(args[0], options.test)
 
     for entry in disco.entries():
         fail_list = []


### PR DESCRIPTION
This adds an `IRecipe` class, a virtual class which acts as documentation for the interface which a `recipe` should have. It also allows testing that a `recipe` implements this interface by using `isinstance(potentially_a_recipe, IRecipe)`. Thanks to `__subclasshook__()` this is possible without `potentially_a_recipe` having to explicitly subclass `IRecipe`.

This is a suggested design change; don't merge it if you don't like it.